### PR TITLE
Clean up license text and ORCID

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -26,7 +26,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \title{Thesis and Project Report Template for \theInstitution{}}
-\author{Joseph~T.~Foley and Marcel~Kyas}
+\author{Joseph~T.~Foley\,\orcidlink{0000-0003-2515-1799} \and Marcel~Kyas\,\orcidlink{0000-0003-1018-3413}}
 \date{2022}{5}{23}%{Year}{Month}{Day}%use numbers
 
 %\DocumentInfo{TYPE}{ABBREVIATION}{DEGREE}{PROGRAM}{ECTS}{School/Department}

--- a/main.tex
+++ b/main.tex
@@ -47,7 +47,7 @@
 \begin{document}
 %% TODO: get the official cover graphic and have the system fill in the fields for you
 \maketitle{}
-\copyrightpage{}
+\copyrightpage{}{0000-0001-2345-6789}
 % If this is a PhD, register for an ISSN and ISBN, then:
 % \copyrightpage{ISSN xxxx-yyyy\\ISBN 978-xxxxxxxxxx\\\url{http://hdl.handle.net/1946/xxxx}\\}
 %\signaturepage{} %Generally only for Print copies

--- a/ruthesis.sty
+++ b/ruthesis.sty
@@ -168,13 +168,15 @@
 \aliaspagestyle{title}{empty}
 %% ----- COPYRIGHT PAGE -----------------------------------------------------------------------
 \RequirePackage{ccicons}
-\newcommand{\copyrightpage}[1]{
+\RequirePackage{orcidlink}
+\newcommand{\copyrightpage}[2]{
   % actually in books, this is often on the left side
   \begin{coverleft}
     \begin{vplace}[1.0] % ratio of space above and below
       \begin{flushleft}
-        #1
-        Copyright \textcopyright{} \the\year{} \theauthor{} \ccbyncnd
+	\thetitle \\[\baselineskip]
+	      \theauthor\orcidlink{#2} (ORCID iD #2)\\[\baselineskip]
+	Copyright \textcopyright{} \the\year{} \ccbyncnd \\
       \end{flushleft}
       This work is licensed under the Creative Commons
       Attribution-NonCom\-mercial-NoDerivatives 4.0 International License

--- a/ruthesis.sty
+++ b/ruthesis.sty
@@ -178,15 +178,20 @@
       \end{flushleft}
       This work is licensed under the Creative Commons
       Attribution-NonCom\-mercial-NoDerivatives 4.0 International License
-      (\url{http://creativecommons.org/licenses/by-nc-nd/4.0/}). You may
+      (\url{http://creativecommons.org/licenses/by-nc-nd/4.0/}).
+      You may
       copy and redistribute the material in any medium or format, provide
       appropriate credit, link to the license and indicate what changes you made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use. You may not use the material for commercial purposes. If you remix, transform or build upon the material, you may not distribute the modified material.
-      The images or other third party material in this thesis are included in
-      the book’s Creative Commons license, unless indicated otherwise in a
-      credit line to the material. If material is not included in the book’s
+
+      The images or other third party material in this work are included in
+      the work's Creative Commons license, unless indicated otherwise in a
+      credit line to the material.
+      If material is not included in the work’s
       Creative Commons license and your intended use is not permitted by
       statutory regulation or exceeds the permitted use, you will need to
-      obtain permission directly from the copyright holder. The use of
+      obtain permission directly from the copyright holder.
+
+      The use of
       general descriptive names, registered names, trademarks, service
       marks, etc. in this publication does not imply, even in the absence of
       a specific statement that such names are exempt from the relevant

--- a/test.tex
+++ b/test.tex
@@ -1,5 +1,5 @@
 \documentclass{memoir}
-\usepackage[online,IS]{ruthesis}
+\usepackage[IS]{ruthesis}
 \usepackage[useregional]{datetime2}
 \usepackage{xparse}%Latex3 argument parsing
 


### PR DESCRIPTION
After discussing with Hákon, I propose the following changes to integrate the ORCID into the thesis.

We should still factor out the copyright page since it needs much more flexibility than we can offer in a style file. What standard should an Icelandic thesis record follow? Everywhere else, publishers stopped including a library of congress record because they needed to include it in different formats, e.g., a British and a German one.